### PR TITLE
mcu: Do not force anonymous MCU, use first MCU as mainsync

### DIFF
--- a/klippy/mcu.py
+++ b/klippy/mcu.py
@@ -919,11 +919,17 @@ def error_help(msg):
 
 def add_printer_objects(printer, config):
     reactor = printer.get_reactor()
+    # first configured MCU has mainsync, others get secondary sync
+    # for best results the MCU with xy should be the first
+    # but this is generally symmetric / doesn't really matter
     mainsync = clocksync.ClockSync(reactor)
-    printer.add_object('mcu', MCU(printer, config.getsection('mcu'), mainsync))
-    for s in config.get_prefix_sections('mcu '):
-        printer.add_object(s.section, MCU(
-            printer, s, clocksync.SecondarySync(reactor, mainsync)))
+    first = True
+    for s in sorted(config.get_prefix_sections('mcu'), key=lambda s: s.section):
+        if s.section == 'mcu' or s.section.startswith('mcu '):
+            printer.add_object(s.section, MCU(
+                printer, s,
+                mainsync if first else clocksync.SecondarySync(reactor, mainsync)))
+            first = False
 
 def get_printer_mcu(printer, name):
     if name == 'mcu':


### PR DESCRIPTION
There is no reason for a main MCU other than clock synchronization.
E.g. if x, y, z are all on different MCUs why should the first be called "mcu" and the others "mcu y", "mcu z", instead everything is symmetric.
Also, on nearly symmetric systems, all pins should be prefixed by their corresponding MCU name.

This solution simply takes the first configured MCU as mainsync. Anonymous MCU is also allowed, so this is backwards compatible.

Signed-off-by: Harald Gutsche <hg42@gmx.net>